### PR TITLE
ios - updated the AppDelegate.m that prevented imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,18 @@
 # react-native-google-places
 iOS/Android Google Places Widgets (Autocomplete Modal) and API Services for React Native Apps
 
+===
+
+## For iOS
+Follow the instruction prescribed in <https://gist.github.com/animeshsinghweb/c4cf9cdf8bdd38a87d59273fc36dbe5a> for using react-native-google-places with cocoapods-keys with this library. 
+
+It serve as the verbose reference for ios the Steps described at the section named "Securing Your API Keys & Making Them Work With Your CI/CD Tools (Optional Steps)" at the end.
+
+
+Instead of passing the API_Key into the AppDelegate, we would use pods keys for security reasons.
+
+
+====
 ### **Notice: The Google Play Services version of the Places SDK for Android (in Google Play Services 16.0.0) is deprecated as of January 29, 2019, and will be turned off on July 29, 2019. A new version of the Places SDK for Android is now available. I suggest you read the documentations again and update your app to use v3.0.1 (or above) of this package**
 
 ## Shots

--- a/ios/RNGooglePlaces.m
+++ b/ios/RNGooglePlaces.m
@@ -9,9 +9,7 @@
 #import <React/RCTConvert.h>
 
 #import <GooglePlaces/GooglePlaces.h>
-
-@import GooglePlaces;
-@import GoogleMaps;
+#import "GoogleMaps/GoogleMaps.h"
 
 @interface RNGooglePlaces() <CLLocationManagerDelegate>
 
@@ -57,6 +55,8 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(init: (NSString *) apiKey)
 {
+    // pass provideAPIKey from AppDelegate using cocoapods-keys
+    //  refer https://gist.github.com/animeshsinghweb/c4cf9cdf8bdd38a87d59273fc36dbe5a
     [GMSPlacesClient provideAPIKey:apiKey];
     [GMSServices provideAPIKey:apiKey];
 }


### PR DESCRIPTION
- the issue resolves the bug related with the import and reference errors
which prevented xcode build
- Also added link to gist for verbose guidance for using this library in ios with cocoapod-keys.

### refer the following screenshots:

<img width="1512" alt="Screenshot 2022-06-17 at 4 43 52 PM" src="https://user-images.githubusercontent.com/16618931/174296268-71104d15-c2d7-4efe-955a-e177887e6c5a.png">
<img width="1512" alt="Screenshot 2022-06-17 at 4 43 58 PM" src="https://user-images.githubusercontent.com/16618931/174296301-11e221be-2c07-4279-8268-a455daa37e6f.png">

